### PR TITLE
Fix screen saver exit on shortcut release

### DIFF
--- a/resources/ahk/src/win/global_win.ahk
+++ b/resources/ahk/src/win/global_win.ahk
@@ -76,11 +76,16 @@ Lalt & q::
     else if (GetKeyState("shift") && GetKeyState("ctrl"))
         send, !+^q
     else if (GetKeyState("Lwin")){
+        ; wait for modifiers to be released so key-up events don't
+        ; immediately cancel the screen saver
+        KeyWait, q
+        KeyWait, LAlt
+        KeyWait, LWin
         if FileExist("exe\screen_save.lnk")
             Run exe\screen_save
         else
             run C:\Windows\System32\scrnsave.scr
-        return 
+        return
     }
 return
 


### PR DESCRIPTION
## Summary
- keep screen saver active when using the `LAlt & q` shortcut

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684479f5e5288327811937db81b6ea29