### PR TITLE
feat(mac): Cross-platform keyboard/mouse control via Hammerspoon

### DIFF
--- a/packages/mac-input/README.md
+++ b/packages/mac-input/README.md
@@ -1,0 +1,69 @@
+# @intuiter/mac-input
+
+macOS keyboard/mouse control for Intuiter using [Hammerspoon](https://www.hammerspoon.org/).
+
+## Features
+
+### Mouse Control (Cmd + IJKL)
+- **Cmd + I/K/J/L**: Move mouse up/down/left/right
+- **Diagonal**: Hold two keys (e.g., Cmd + I + L for up-right)
+- **Speed**: Hold Ctrl for instant max speed
+
+### Mouse Clicks
+- **Cmd + U**: Left click (hold for drag)
+- **Cmd + O**: Right click
+- **Cmd + M**: Middle click
+
+### Scrolling
+- **Alt + U/O**: Scroll up/down
+- **Alt + Shift + U/O**: Scroll left/right
+- **Cmd + H/P**: Scroll up/down (alternate)
+
+### Text Navigation (Alt + IJKL)
+- **Alt + I/K**: Arrow up/down
+- **Alt + J/L**: Word left/right
+- **Alt + Shift + variants**: Select while moving
+- **Alt + Ctrl + variants**: Repeat while held
+
+### Text Selection
+- **Alt + W**: Select word (press twice for line)
+- **Alt + A**: Select line (press twice for paragraph)
+- **Alt + Shift + W**: Select entire line
+
+## Installation
+
+### Via npm
+```bash
+cd packages/mac-input
+npm run install-config
+```
+
+### Manual
+1. Install Hammerspoon: `brew install --cask hammerspoon`
+2. Copy files from `hammerspoon/` to `~/.hammerspoon/`
+3. Grant Accessibility permissions in System Preferences
+4. Reload config: Cmd + Ctrl + R
+
+## Configuration
+
+Edit `~/.hammerspoon/config.lua`:
+
+```lua
+config.mouse = {
+    maxVelocity = 5,
+    acceleration = 0.2,
+    pollInterval = 0.001,
+}
+```
+
+## Windows/Mac Comparison
+
+| Feature | Windows (AHK) | macOS (Hammerspoon) |
+|---------|---------------|---------------------|
+| Mouse movement | LWin + IJKL | Cmd + IJKL |
+| Clicks | LWin + U/O | Cmd + U/O |
+| Text nav | LAlt + IJKL | Alt + IJKL |
+
+## License
+
+MIT

--- a/packages/mac-input/hammerspoon/mouse.lua
+++ b/packages/mac-input/hammerspoon/mouse.lua
@@ -48,7 +48,7 @@ local function stopMouseMove()
 end
 
 -- Generic mouse movement function
-local function startMouseMove(dirX, dirY)
+local function startMouseMove()
     stopMouseMove()
     state.velocity = 0
 
@@ -105,19 +105,7 @@ local function startMouseMove(dirX, dirY)
     end)
 end
 
--- Mouse click functions (equivalent to click_left, click_right, click_mid in AHK)
-local function mouseClick(button)
-    local pos = hs.mouse.absolutePosition()
-    hs.eventtap.event.newMouseEvent(
-        hs.eventtap.event.types[button .. "MouseDown"],
-        pos
-    ):post()
-    hs.eventtap.event.newMouseEvent(
-        hs.eventtap.event.types[button .. "MouseUp"],
-        pos
-    ):post()
-end
-
+-- Mouse click functions
 local function mouseDown(button)
     local pos = hs.mouse.absolutePosition()
     hs.eventtap.event.newMouseEvent(
@@ -134,7 +122,7 @@ local function mouseUp(button)
     ):post()
 end
 
--- Scroll functions (equivalent to scroll_up, scroll_down, etc. in AHK)
+-- Scroll functions
 local scrollState = {
     timer = nil,
     divisor = 3,
@@ -168,12 +156,10 @@ local function startScroll(dx, dy)
 end
 
 -- Key bindings for mouse movement (Cmd + IJKL)
--- Equivalent to Lwin & i, Lwin & k, Lwin & j, Lwin & l in AHK
 local moveKeys = {"i", "j", "k", "l"}
 local moveBindings = {}
 
 for _, key in ipairs(moveKeys) do
-    -- Key down
     moveBindings[key .. "_down"] = hs.hotkey.bind({"cmd"}, key, function()
         setKeyPressed(key, true)
         startMouseMove()
@@ -182,8 +168,7 @@ for _, key in ipairs(moveKeys) do
     end)
 end
 
--- Mouse click bindings (Cmd + U for left click, Cmd + O for right click)
--- Equivalent to Lwin & u, Lwin & o in AHK
+-- Mouse click bindings
 local leftClickBinding = hs.hotkey.bind({"cmd"}, "u", function()
     mouseDown("left")
 end, function()
@@ -196,15 +181,13 @@ end, function()
     mouseUp("right")
 end)
 
--- Middle click (Cmd + M)
 local midClickBinding = hs.hotkey.bind({"cmd"}, "m", function()
     mouseDown("middle")
 end, function()
     mouseUp("middle")
 end)
 
--- Scroll bindings (Alt + U for scroll up, Alt + O for scroll down)
--- Equivalent to Lalt & u, Lalt & o in AHK
+-- Scroll bindings
 local scrollUpBinding = hs.hotkey.bind({"alt"}, "u", function()
     startScroll(0, 5)
 end, function()
@@ -217,7 +200,6 @@ end, function()
     stopScroll()
 end)
 
--- Horizontal scroll with Shift modifier
 local scrollLeftBinding = hs.hotkey.bind({"alt", "shift"}, "u", function()
     startScroll(5, 0)
 end, function()
@@ -230,7 +212,6 @@ end, function()
     stopScroll()
 end)
 
--- Additional scroll binding (Cmd + H for scroll up, Cmd + P for scroll down)
 local scrollUpAltBinding = hs.hotkey.bind({"cmd"}, "h", function()
     startScroll(0, 5)
 end, function()

--- a/packages/mac-input/hammerspoon/text.lua
+++ b/packages/mac-input/hammerspoon/text.lua
@@ -1,0 +1,235 @@
+-- Intuiter Text Navigation for macOS
+-- Equivalent to packages/ahk/src/right/arrow_ijkl.ahk and src/left/text_select.ahk
+
+local config = require("config")
+
+local text = {}
+
+-- Helper function to send key events
+local function sendKey(key, modifiers)
+    modifiers = modifiers or {}
+    hs.eventtap.keyStroke(modifiers, key, 0)
+end
+
+-- Helper for repeated key sending while held
+local function createRepeatingKey(modifiers, key, targetKey, targetMods)
+    local timer = nil
+
+    return hs.hotkey.bind(modifiers, key, function()
+        -- First press
+        sendKey(targetKey, targetMods)
+
+        -- Start repeating
+        timer = hs.timer.doEvery(0.001, function()
+            sendKey(targetKey, targetMods)
+        end)
+    end, function()
+        -- Key released
+        if timer then
+            timer:stop()
+            timer = nil
+        end
+    end)
+end
+
+-- Text navigation bindings (Alt + IJKL)
+-- Equivalent to Lalt & i, Lalt & k, Lalt & j, Lalt & l in AHK
+
+-- Alt + I: Up arrow (single press)
+local textUpBinding = hs.hotkey.bind({"alt"}, "i", function()
+    sendKey("up")
+end)
+
+local textUpRepeatBinding = createRepeatingKey({"alt", "ctrl"}, "i", "up", {})
+local textUpSelectRepeatBinding = createRepeatingKey({"alt", "ctrl", "shift"}, "i", "up", {"shift"})
+local textUpSelectBinding = hs.hotkey.bind({"alt", "shift"}, "i", function()
+    sendKey("up", {"shift"})
+end)
+
+-- Alt + K: Down arrow
+local textDownBinding = hs.hotkey.bind({"alt"}, "k", function()
+    sendKey("down")
+end)
+
+local textDownRepeatBinding = createRepeatingKey({"alt", "ctrl"}, "k", "down", {})
+local textDownSelectRepeatBinding = createRepeatingKey({"alt", "ctrl", "shift"}, "k", "down", {"shift"})
+local textDownSelectBinding = hs.hotkey.bind({"alt", "shift"}, "k", function()
+    sendKey("down", {"shift"})
+end)
+
+-- Alt + J: Word left (Ctrl+Left on Windows = Option+Left on Mac)
+local textWordLeftBinding = hs.hotkey.bind({"alt"}, "j", function()
+    sendKey("left", {"alt"})
+end)
+
+-- Alt + Shift + J: Select word left
+local textWordLeftSelectBinding = hs.hotkey.bind({"alt", "shift"}, "j", function()
+    sendKey("left", {"alt", "shift"})
+end)
+
+-- Alt + Ctrl + J: Repeat left while held
+local textLeftRepeatBinding = createRepeatingKey({"alt", "ctrl"}, "j", "left", {})
+
+-- Alt + Ctrl + Shift + J: Select to beginning of line
+local textSelectToHomeBinding = hs.hotkey.bind({"alt", "ctrl", "shift"}, "j", function()
+    sendKey("left", {"cmd", "shift"})
+end)
+
+-- Alt + L: Word right (Ctrl+Right on Windows = Option+Right on Mac)
+local textWordRightBinding = hs.hotkey.bind({"alt"}, "l", function()
+    sendKey("right", {"alt"})
+end)
+
+-- Alt + Shift + L: Select word right
+local textWordRightSelectBinding = hs.hotkey.bind({"alt", "shift"}, "l", function()
+    sendKey("right", {"alt", "shift"})
+end)
+
+-- Alt + Ctrl + L: Repeat right while held
+local textRightRepeatBinding = createRepeatingKey({"alt", "ctrl"}, "l", "right", {})
+
+-- Alt + Ctrl + Shift + L: Select to end of line
+local textSelectToEndBinding = hs.hotkey.bind({"alt", "ctrl", "shift"}, "l", function()
+    sendKey("right", {"cmd", "shift"})
+end)
+
+-- Text selection shortcuts (Alt + W and Alt + A)
+-- Equivalent to Lalt & w, Lalt & a in AHK
+
+-- Alt + W: Select word (first press), select line (second press)
+local selectState = {
+    pressCount = 0,
+    timer = nil,
+}
+
+local textSelectWordBinding = hs.hotkey.bind({"alt"}, "w", function()
+    if selectState.timer then
+        selectState.timer:stop()
+    end
+
+    selectState.pressCount = selectState.pressCount + 1
+
+    if selectState.pressCount == 1 then
+        -- Select word: move left, then Option+Right, then Shift+Option+Left
+        sendKey("left")
+        hs.timer.doAfter(0.01, function()
+            sendKey("right", {"alt"})
+            hs.timer.doAfter(0.01, function()
+                sendKey("left", {"alt", "shift"})
+            end)
+        end)
+    elseif selectState.pressCount == 2 then
+        -- Select line: End then Shift+Home
+        sendKey("right", {"cmd"})
+        hs.timer.doAfter(0.01, function()
+            sendKey("left", {"cmd", "shift"})
+        end)
+        selectState.pressCount = 0
+    end
+
+    -- Reset count after timeout
+    selectState.timer = hs.timer.doAfter(0.3, function()
+        selectState.pressCount = 0
+    end)
+end)
+
+-- Alt + Shift + W: Select entire line
+local textSelectLineBinding = hs.hotkey.bind({"alt", "shift"}, "w", function()
+    sendKey("left", {"cmd"})
+    hs.timer.doAfter(0.01, function()
+        sendKey("right", {"cmd", "shift"})
+    end)
+end)
+
+-- Alt + Ctrl + W: Select current and next line
+local textSelectMultiLineBinding = hs.hotkey.bind({"alt", "ctrl"}, "w", function()
+    sendKey("up")
+    hs.timer.doAfter(0.01, function()
+        sendKey("right", {"cmd"})
+        hs.timer.doAfter(0.01, function()
+            sendKey("down", {"shift"})
+            hs.timer.doAfter(0.01, function()
+                sendKey("right", {"cmd", "shift"})
+            end)
+        end)
+    end)
+end)
+
+-- Alt + A: Select line (first press), select paragraph (second press)
+local selectAState = {
+    pressCount = 0,
+    timer = nil,
+}
+
+local textSelectABinding = hs.hotkey.bind({"alt"}, "a", function()
+    if selectAState.timer then
+        selectAState.timer:stop()
+    end
+
+    selectAState.pressCount = selectAState.pressCount + 1
+
+    if selectAState.pressCount == 1 then
+        -- Select line: End then Shift+Home
+        sendKey("right", {"cmd"})
+        hs.timer.doAfter(0.01, function()
+            sendKey("left", {"cmd", "shift"})
+        end)
+    elseif selectAState.pressCount == 2 then
+        -- Select paragraph
+        sendKey("up")
+        hs.timer.doAfter(0.01, function()
+            sendKey("right", {"cmd"})
+            hs.timer.doAfter(0.01, function()
+                sendKey("down", {"shift"})
+                hs.timer.doAfter(0.01, function()
+                    sendKey("right", {"cmd", "shift"})
+                end)
+            end)
+        end)
+        selectAState.pressCount = 0
+    end
+
+    -- Reset count after timeout
+    selectAState.timer = hs.timer.doAfter(0.3, function()
+        selectAState.pressCount = 0
+    end)
+end)
+
+-- Home and End shortcuts using Alt + U/O with Ctrl+Shift
+-- Alt + Ctrl + Shift + U: Go to beginning of document
+local textHomeDocBinding = hs.hotkey.bind({"alt", "ctrl", "shift"}, "u", function()
+    sendKey("up", {"cmd"})
+end)
+
+-- Alt + Ctrl + Shift + O: Go to end of document
+local textEndDocBinding = hs.hotkey.bind({"alt", "ctrl", "shift"}, "o", function()
+    sendKey("down", {"cmd"})
+end)
+
+-- Store bindings for cleanup
+text.bindings = {
+    textUpBinding,
+    textUpRepeatBinding,
+    textUpSelectRepeatBinding,
+    textUpSelectBinding,
+    textDownBinding,
+    textDownRepeatBinding,
+    textDownSelectRepeatBinding,
+    textDownSelectBinding,
+    textWordLeftBinding,
+    textWordLeftSelectBinding,
+    textLeftRepeatBinding,
+    textSelectToHomeBinding,
+    textWordRightBinding,
+    textWordRightSelectBinding,
+    textRightRepeatBinding,
+    textSelectToEndBinding,
+    textSelectWordBinding,
+    textSelectLineBinding,
+    textSelectMultiLineBinding,
+    textSelectABinding,
+    textHomeDocBinding,
+    textEndDocBinding,
+}
+
+return text

--- a/packages/mac-input/package.json
+++ b/packages/mac-input/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "description": "Hammerspoon configuration for Intuiter on macOS",
   "scripts": {
-    "install": "node scripts/install.js",
-    "uninstall": "node scripts/uninstall.js"
+    "install-config": "node scripts/install.js",
+    "uninstall-config": "node scripts/uninstall.js"
+  },
+  "os": ["darwin"],
+  "engines": {
+    "node": ">=20.9.0"
   }
 }

--- a/packages/mac-input/scripts/install.js
+++ b/packages/mac-input/scripts/install.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Intuiter macOS Installation Script
+ * Installs Hammerspoon configuration for keyboard/mouse control
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const HAMMERSPOON_CONFIG_DIR = path.join(os.homedir(), '.hammerspoon');
+const SOURCE_DIR = path.join(__dirname, '..', 'hammerspoon');
+
+function log(message) {
+    console.log(`[Intuiter] ${message}`);
+}
+
+function error(message) {
+    console.error(`[Intuiter Error] ${message}`);
+}
+
+function checkHammerspoonApp() {
+    return fs.existsSync('/Applications/Hammerspoon.app');
+}
+
+function installHammerspoon() {
+    log('Hammerspoon not found. Attempting to install via Homebrew...');
+
+    try {
+        execSync('which brew', { stdio: 'pipe' });
+    } catch {
+        error('Homebrew is not installed. Please install Homebrew first:');
+        error('  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"');
+        error('Then run this installation again.');
+        process.exit(1);
+    }
+
+    try {
+        log('Installing Hammerspoon via Homebrew Cask...');
+        execSync('brew install --cask hammerspoon', { stdio: 'inherit' });
+        log('Hammerspoon installed successfully!');
+    } catch (e) {
+        error(`Failed to install Hammerspoon: ${e.message}`);
+        error('Please install Hammerspoon manually from: https://www.hammerspoon.org/');
+        process.exit(1);
+    }
+}
+
+function backupExistingConfig() {
+    const initFile = path.join(HAMMERSPOON_CONFIG_DIR, 'init.lua');
+    if (fs.existsSync(initFile)) {
+        const backupFile = path.join(HAMMERSPOON_CONFIG_DIR, 'init.lua.backup');
+        log(`Backing up existing init.lua to ${backupFile}`);
+        fs.copyFileSync(initFile, backupFile);
+    }
+}
+
+function installConfig() {
+    log('Installing Intuiter Hammerspoon configuration...');
+
+    if (!fs.existsSync(HAMMERSPOON_CONFIG_DIR)) {
+        fs.mkdirSync(HAMMERSPOON_CONFIG_DIR, { recursive: true });
+    }
+
+    backupExistingConfig();
+
+    const files = ['init.lua', 'config.lua', 'mouse.lua', 'text.lua'];
+
+    for (const file of files) {
+        const source = path.join(SOURCE_DIR, file);
+        const dest = path.join(HAMMERSPOON_CONFIG_DIR, file);
+
+        if (fs.existsSync(source)) {
+            fs.copyFileSync(source, dest);
+            log(`  Installed ${file}`);
+        } else {
+            error(`  Source file not found: ${source}`);
+        }
+    }
+
+    log('Configuration installed successfully!');
+}
+
+function reloadHammerspoon() {
+    log('Reloading Hammerspoon configuration...');
+
+    try {
+        execSync('hs -c "hs.reload()"', { stdio: 'pipe' });
+        log('Hammerspoon reloaded!');
+    } catch {
+        log('Could not reload automatically. Please reload Hammerspoon manually.');
+        log('  Click the Hammerspoon menubar icon and select "Reload Config"');
+    }
+}
+
+function printInstructions() {
+    log('');
+    log('=== Setup Complete ===');
+    log('');
+    log('Important: Hammerspoon needs Accessibility permissions.');
+    log('');
+    log('1. Open System Preferences > Security & Privacy > Privacy > Accessibility');
+    log('2. Add Hammerspoon to the list and enable it');
+    log('');
+    log('=== Key Bindings ===');
+    log('');
+    log('Mouse Movement (Cmd + IJKL):');
+    log('  Cmd + I/K/J/L: Move up/down/left/right');
+    log('  Hold Ctrl for instant max speed');
+    log('');
+    log('Mouse Clicks:');
+    log('  Cmd + U: Left click');
+    log('  Cmd + O: Right click');
+    log('  Cmd + M: Middle click');
+    log('');
+    log('Scroll:');
+    log('  Alt + U/O: Scroll up/down');
+    log('');
+    log('Text Navigation (Alt + IJKL):');
+    log('  Alt + I/K: Up/Down arrow');
+    log('  Alt + J/L: Word left/right');
+    log('');
+    log('Reload Config: Cmd + Ctrl + R');
+    log('');
+}
+
+function main() {
+    log('Intuiter macOS Installation');
+    log('===========================');
+
+    if (process.platform !== 'darwin') {
+        error('This script is for macOS only.');
+        process.exit(1);
+    }
+
+    if (!checkHammerspoonApp()) {
+        installHammerspoon();
+    } else {
+        log('Hammerspoon is already installed.');
+    }
+
+    installConfig();
+    reloadHammerspoon();
+    printInstructions();
+}
+
+main();

--- a/packages/mac-input/scripts/uninstall.js
+++ b/packages/mac-input/scripts/uninstall.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Intuiter macOS Uninstallation Script
+ * Removes Hammerspoon configuration
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const HAMMERSPOON_CONFIG_DIR = path.join(os.homedir(), '.hammerspoon');
+
+function log(message) {
+    console.log(`[Intuiter] ${message}`);
+}
+
+function removeConfig() {
+    log('Removing Intuiter Hammerspoon configuration...');
+
+    const files = ['init.lua', 'config.lua', 'mouse.lua', 'text.lua'];
+
+    for (const file of files) {
+        const filePath = path.join(HAMMERSPOON_CONFIG_DIR, file);
+        if (fs.existsSync(filePath)) {
+            fs.unlinkSync(filePath);
+            log(`  Removed ${file}`);
+        }
+    }
+
+    const backupFile = path.join(HAMMERSPOON_CONFIG_DIR, 'init.lua.backup');
+    if (fs.existsSync(backupFile)) {
+        const initFile = path.join(HAMMERSPOON_CONFIG_DIR, 'init.lua');
+        fs.copyFileSync(backupFile, initFile);
+        fs.unlinkSync(backupFile);
+        log('  Restored original init.lua from backup');
+    }
+
+    log('Uninstallation complete!');
+}
+
+function main() {
+    log('Intuiter macOS Uninstallation');
+    log('=============================');
+
+    if (process.platform !== 'darwin') {
+        log('This script is for macOS only.');
+        process.exit(1);
+    }
+
+    removeConfig();
+}
+
+main();

--- a/src/renderer/components/templates/Run.vue
+++ b/src/renderer/components/templates/Run.vue
@@ -11,39 +11,149 @@
 import { run } from 'node-cmd'
 import { defineComponent, onMounted } from '@vue/composition-api'
 import { useStore } from '@nuxtjs/composition-api'
-import { resolve } from 'path'
+import { resolve, join } from 'path'
 import { remote } from 'electron'
 import DancingButton from 'dancing-button'
 import { promises } from 'fs'
+import { platform, homedir } from 'os'
+import { execSync } from 'child_process'
 
 import useToast from '~/composables/useToast'
 
 import type { Store } from 'vuex'
 import type { State } from '~/store/'
 
+// Windows paths (AHK)
 const AHK_PATH = 'resources\\ahk\\exe\\ahk\\AutoHotkey.exe'
 const MAKER_PATH = 'resources\\ahk\\make.ahk'
 
-const exists = async path => await promises.stat(path).catch(() => false)
+// macOS paths (Hammerspoon)
+const MAC_HAMMERSPOON_DIR = '.hammerspoon'
+const MAC_INPUT_PATH = 'resources/mac-input/hammerspoon'
+
+const exists = async (path: string) => await promises.stat(path).catch(() => false)
 
 export default defineComponent({
   setup(_, context) {
     const store: Store<State> = useStore()
     const toast = useToast(context.root)
+    const currentPlatform = platform()
 
-    // Run Command
-    async function make() {
+    // Check if Hammerspoon is installed on macOS
+    async function isHammerspoonInstalled(): Promise<boolean> {
+      try {
+        const appExists = await exists('/Applications/Hammerspoon.app')
+        return appExists !== false
+      } catch {
+        return false
+      }
+    }
+
+    // Install Hammerspoon configuration on macOS
+    async function installMacConfig(): Promise<boolean> {
+      const root = resolve(remote.app.getAppPath(), '../../')
+      const sourcePath = resolve(root, MAC_INPUT_PATH)
+      const destPath = join(homedir(), MAC_HAMMERSPOON_DIR)
+
+      // Check if source files exist
+      if (!(await exists(sourcePath))) {
+        toast.error('Mac input files not found')
+        return false
+      }
+
+      // Create destination directory
+      try {
+        await promises.mkdir(destPath, { recursive: true })
+      } catch {
+        // Directory may already exist
+      }
+
+      // Copy configuration files
+      const files = ['init.lua', 'config.lua', 'mouse.lua', 'text.lua']
+      for (const file of files) {
+        const src = join(sourcePath, file)
+        const dest = join(destPath, file)
+        if (await exists(src)) {
+          await promises.copyFile(src, dest)
+        }
+      }
+
+      return true
+    }
+
+    // Reload Hammerspoon configuration
+    function reloadHammerspoon(): void {
+      try {
+        execSync('open -a Hammerspoon')
+        // Give it time to start, then reload
+        setTimeout(() => {
+          try {
+            execSync('hs -c "hs.reload()"', { stdio: 'pipe' })
+          } catch {
+            // CLI may not be installed, that's okay
+          }
+        }, 1000)
+      } catch {
+        // Hammerspoon may not be running
+      }
+    }
+
+    // Run on macOS
+    async function makeMac() {
+      store.state.loading = true
+
+      // Check if Hammerspoon is installed
+      const hammerspoonInstalled = await isHammerspoonInstalled()
+      if (!hammerspoonInstalled) {
+        toast.error('Hammerspoon not installed')
+        toast.info('Install via: brew install --cask hammerspoon')
+        store.state.loading = false
+        return
+      }
+
+      // Install configuration
+      const installed = await installMacConfig()
+      if (!installed) {
+        store.state.loading = false
+        return
+      }
+
+      // Reload Hammerspoon
+      reloadHammerspoon()
+
+      toast.success('Intuiter Running')
+      toast.info('Hammerspoon config loaded')
+      store.state.loading = false
+    }
+
+    // Run on Windows (original AHK logic)
+    async function makeWindows() {
       const root = resolve(remote.app.getAppPath(), '../../')
       const ahkPath = resolve(root, AHK_PATH)
       const makePath = resolve(root, MAKER_PATH)
       store.state.loading = true
       const exist = (await exists(ahkPath)) && (await exists(makePath))
-      if (!exist) return toast.error('No File')
+      if (!exist) {
+        toast.error('No File')
+        store.state.loading = false
+        return
+      }
       run(`"${ahkPath}" "${makePath}"`, () => {
         toast.success('Intuiter Running')
         toast.info('You can close Window')
-      store.state.loading = false
+        store.state.loading = false
       })
+    }
+
+    // Platform-aware make function
+    async function make() {
+      if (currentPlatform === 'darwin') {
+        await makeMac()
+      } else if (currentPlatform === 'win32') {
+        await makeWindows()
+      } else {
+        toast.error(`Unsupported platform: ${currentPlatform}`)
+      }
     }
 
     onMounted(() => {


### PR DESCRIPTION
## Summary

- Add macOS equivalent to Windows AHK input control using Hammerspoon
- Implement platform detection in Run.vue to automatically choose the appropriate backend
- Create `@intuiter/mac-input` package with modular Lua configuration

## Features

### Mouse Control (Cmd + IJKL)
- Smooth, accelerated mouse movement via keyboard
- Diagonal movement support (hold two keys)
- Ctrl modifier for instant max speed

### Mouse Clicks
- Cmd + U: Left click (hold for drag)
- Cmd + O: Right click
- Cmd + M: Middle click

### Scrolling
- Alt + U/O: Scroll up/down
- Alt + Shift + U/O: Scroll left/right

### Text Navigation (Alt + IJKL)
- Alt + I/K: Arrow up/down
- Alt + J/L: Word left/right (Option+Arrow on Mac)
- Alt + Shift + variants: Select while moving
- Alt + Ctrl + variants: Repeat while held

### Text Selection
- Alt + W: Select word (press twice for line)
- Alt + A: Select line (press twice for paragraph)

## Architecture

```
packages/
  ahk/           # Windows (existing)
  mac-input/     # macOS (new)
    hammerspoon/
      init.lua   # Entry point
      config.lua # Settings (mirrors AHK const.ahk)
      mouse.lua  # Mouse movement, clicks, scroll
      text.lua   # Text navigation and selection
    scripts/
      install.js   # Setup Hammerspoon config
      uninstall.js # Cleanup
```

## Platform Detection

Run.vue now detects the OS and uses:
- **Windows (win32)**: AutoHotkey via existing flow
- **macOS (darwin)**: Hammerspoon via new flow

## Test plan

- [ ] Verify Windows AHK functionality unchanged
- [ ] Test macOS Hammerspoon installation via script
- [ ] Test mouse movement (all directions, diagonals)
- [ ] Test mouse clicks (left, right, middle)
- [ ] Test scrolling (vertical, horizontal)
- [ ] Test text navigation shortcuts
- [ ] Test text selection shortcuts
- [ ] Verify Electron app detects platform correctly

## Prerequisites for macOS

1. Hammerspoon installed: `brew install --cask hammerspoon`
2. Accessibility permissions granted in System Preferences

---

Generated with [Claude Code](https://claude.com/claude-code)